### PR TITLE
Update for Swift 4.2; Fix typo

### DIFF
--- a/test/BackgroundTask/BackgroundTask.swift
+++ b/test/BackgroundTask/BackgroundTask.swift
@@ -15,17 +15,17 @@ class BackgroundTask {
     
     // MARK: - Methods
     func startBackgroundTask() {
-        NotificationCenter.default.addObserver(self, selector: #selector(interuptedAudio), name: .AVAudioSessionInterruption, object: AVAudioSession.sharedInstance())
+        NotificationCenter.default.addObserver(self, selector: #selector(interruptedAudio), name: AVAudioSession.interruptionNotification, object: AVAudioSession.sharedInstance())
         self.playAudio()
     }
     
     func stopBackgroundTask() {
-        NotificationCenter.default.removeObserver(self, name: .AVAudioSessionInterruption, object: nil)
+        NotificationCenter.default.removeObserver(self, name: AVAudioSession.interruptionNotification, object: nil)
         player.stop()
     }
     
-    @objc fileprivate func interuptedAudio(_ notification: Notification) {
-        if notification.name == .AVAudioSessionInterruption && notification.userInfo != nil {
+    @objc fileprivate func interruptedAudio(_ notification: Notification) {
+        if notification.name == AVAudioSession.interruptionNotification && notification.userInfo != nil {
             var info = notification.userInfo!
             var intValue = 0
             (info[AVAudioSessionInterruptionTypeKey]! as AnyObject).getValue(&intValue)
@@ -37,7 +37,7 @@ class BackgroundTask {
         do {
             let bundle = Bundle.main.path(forResource: "blank", ofType: "wav")
             let alertSound = URL(fileURLWithPath: bundle!)
-            try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback, with: .mixWithOthers)
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
             try AVAudioSession.sharedInstance().setActive(true)
             try self.player = AVAudioPlayer(contentsOf: alertSound)
             // Play audio forever by setting num of loops to -1


### PR DESCRIPTION
Original file didn't work on Swift 4.2, updated it to make it work!

I believe older iOS version (< 10) won't work with the new code because a more recent API is used.
Not sure if it is possible to still use older API without using ObjC. In my case it's totally fine to support iOS 10+ only anyway